### PR TITLE
fix(workflows): pass accepted plan into implement stage

### DIFF
--- a/src/__tests__/workflow-service.test.ts
+++ b/src/__tests__/workflow-service.test.ts
@@ -480,7 +480,7 @@ describe("WorkflowService", () => {
   });
 
   it("resumes through implement, verify, review and pauses before PR", async () => {
-    const { store, service } = await createService();
+    const { store, service, runner } = await createService();
     const started = await service.start("42");
     const resumed = await service.resume(started.id);
 
@@ -489,6 +489,9 @@ describe("WorkflowService", () => {
     const snapshot = service.getSnapshot(started.id);
     expect(snapshot.tasks.map((task) => task.type)).toEqual(["triage", "plan", "implement", "verify", "review"]);
     expect(snapshot.approvals.at(-1)?.stage).toBe("review");
+    const implementRequest = runner.startedRequests.find((request) => request.taskType === "implement");
+    expect(implementRequest?.context.extraInstructions?.join("\n")).toContain("Accepted plan:");
+    expect(implementRequest?.context.extraInstructions?.join("\n")).toContain("Implementation steps");
 
     store.close();
   });

--- a/src/workflows/service.ts
+++ b/src/workflows/service.ts
@@ -657,6 +657,10 @@ export class WorkflowService {
     stage: WorkflowTaskType,
     overrides: StageContextOverrides = {},
   ): Promise<WorkflowInstance> {
+    const extraInstructions = [...(overrides.extraInstructions ?? [])];
+    if (stage === "implement") {
+      extraInstructions.push(...(await this.latestArtifactInstructions(workflow.id, "plan", "Accepted plan")));
+    }
     const executor = this.resolveExecutor(stage);
     const task = this.store.createTask({
       workflowInstanceId: workflow.id,
@@ -701,7 +705,7 @@ export class WorkflowService {
         comments: overrides.comments,
         changedFilesHint: overrides.changedFilesHint,
         skills: resolveSkills(this.config, stage, overrides.changedFilesHint),
-        extraInstructions: overrides.extraInstructions,
+        extraInstructions: extraInstructions.length > 0 ? extraInstructions : undefined,
       },
       expectedArtifacts: [artifactKindForStage(stage)],
     };


### PR DESCRIPTION
## Summary
- attach the latest accepted plan artifact to implement-stage executor requests
- add workflow-service coverage for the accepted-plan handoff

## Testing
- node ./node_modules/vitest/vitest.mjs run --config vitest.config.ts src/__tests__/workflow-service.test.ts