### PR TITLE
Harden hub workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ That script:
   - `devagent-runner`
   - `devagent-hub`
 
+The installed `devagent-hub` wrapper now boots through Node so the Hub CLI can safely use
+`better-sqlite3` even when Bun is the package manager for the repo.
+
 ## CLI
 
 ```bash
@@ -101,6 +104,9 @@ devagent-hub list
 devagent-hub status <workflow-id>
 devagent-hub status <workflow-id> --json
 ```
+
+Hub state lives under `~/.config/devagent-hub` by default. To isolate Hub state without changing
+auth discovery for `gh` or `devagent`, set `DEVAGENT_HUB_CONFIG_DIR=/path/to/hub-state`.
 
 ## Review The Plan
 
@@ -167,6 +173,10 @@ How feedback is used:
 Use `status --json` only for scripts or external tooling. The default text output is the intended
 operator view.
 
+If the target repo does not contain `WORKFLOW.md`, Hub now infers safe defaults for Bun/Node and
+Python repos and prints the inferred verify commands into the early workflow context. If it cannot
+infer a safe profile, it fails fast and asks the operator to add `WORKFLOW.md`.
+
 ## Review Before PR
 
 After `implement -> verify -> review` completes cleanly, Hub pauses again before PR handoff.
@@ -199,6 +209,10 @@ How feedback is used:
 
 - a rejected final approval note becomes input to the next `repair`
 - Hub then reruns `repair -> verify -> review` and pauses again
+
+When `implement` or `repair` reports success but produces no repository changes, Hub retries once
+with stronger instructions. For `devagent`, that retry resumes the previous session context so the
+follow-up run can continue from the earlier analysis instead of starting cold.
 
 ## Post-PR Feedback
 
@@ -249,7 +263,7 @@ bun run check:oss
 
 - the supported contributor path is the four-repo sibling checkout plus bootstrap flow
 - only the DevAgent executor path is production-grade
-- package publication and a simpler single-repo install story are deferred
+- package publication and a simpler single-repo install story are still evolving
 
 Additional baseline commands:
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -76,6 +76,10 @@ repair:
 - skill selection by stage and path
 - PR draft/open rules
 
+If a target repo has no `WORKFLOW.md`, Hub falls back to inferred safe defaults only for Bun/Node
+and Python repositories. It injects the inferred verify commands into early workflow context and
+fails fast for unknown repo types instead of guessing.
+
 ## How work enters this repo
 
 Most changes land through self-hosting Hub workflows or direct contributor changes to orchestration,
@@ -84,6 +88,10 @@ persistence, GitHub integration, and operator CLI behavior.
 Hub resolves the selected profile into an SDK `ExecutorSpec`, submits a `TaskExecutionRequest` to
 `devagent-runner`, and waits for normalized events/results/artifacts. Hub does not shell out to
 executors directly.
+
+Execution results may carry opaque executor session metadata. Hub persists that metadata and can
+resume the prior `devagent` session for iterative follow-up runs such as no-progress retries and
+future multi-step repair or planning flows.
 
 ## Recommended Local Validation Profile
 

--- a/baseline.json
+++ b/baseline.json
@@ -5,25 +5,25 @@
       "name": "devagent-sdk",
       "url": "https://github.com/egavrin/devagent-sdk",
       "branch": "main",
-      "sha": "e45e3d8e80fbdcdee98504fa808c7f833e296410"
+      "sha": "bf94ad86a31ddbd970a42b0b49f08042092c610a"
     },
     "devagent-runner": {
       "name": "devagent-runner",
       "url": "https://github.com/egavrin/devagent-runner",
       "branch": "main",
-      "sha": "271e1cf997bc0e7f8ed13efe2bcdccc858ece206"
+      "sha": "7b2a7839aca07463f80ad39a44346f7efa54b7b1"
     },
     "devagent": {
       "name": "devagent",
       "url": "https://github.com/egavrin/devagent",
       "branch": "main",
-      "sha": "bd02c856a13f6936af4a58d23505c2b3250e4500"
+      "sha": "bd1a4206134b4bbda2374b09e23a7069f55fe9f5"
     },
     "devagent-hub": {
       "name": "devagent-hub",
       "url": "https://github.com/egavrin/devagent-hub",
       "branch": "main",
-      "sha": "74afaf60db67fc7639b81d94abb4d657b81525e1"
+      "sha": "8b8d7ba5a41708211e060a59cc4a1832b321577f"
     }
   }
 }

--- a/bin/devagent-hub.js
+++ b/bin/devagent-hub.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const entry = resolve(root, "..", "dist", "cli", "index.js");
+
+if (!existsSync(entry)) {
+  process.stderr.write("devagent-hub is not built. Run `bun run build` before invoking the local wrapper.\n");
+  process.exit(1);
+}
+
+await import(pathToFileURL(entry).href);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=20"
   },
   "bin": {
-    "devagent-hub": "dist/cli/index.js"
+    "devagent-hub": "bin/devagent-hub.js"
   },
   "scripts": {
     "build": "bunx tsc -p tsconfig.json",

--- a/src/__tests__/canonical-store.test.ts
+++ b/src/__tests__/canonical-store.test.ts
@@ -74,6 +74,12 @@ describe("CanonicalStore", () => {
       executorId: "devagent",
       runnerId: "run-1",
       workspacePath: "/tmp/workspace",
+      session: {
+        kind: "devagent-headless-v1",
+        payload: {
+          messages: [],
+        },
+      },
     });
     const event: TaskExecutionEvent = {
       protocolVersion: PROTOCOL_VERSION,
@@ -118,6 +124,7 @@ describe("CanonicalStore", () => {
     expect(snapshot.workItem.id).toBe(workItem.id);
     expect(snapshot.tasks).toHaveLength(1);
     expect(snapshot.attempts).toHaveLength(1);
+    expect(snapshot.attempts[0]?.session?.kind).toBe("devagent-headless-v1");
     expect(snapshot.events).toHaveLength(1);
     expect(snapshot.artifacts).toHaveLength(1);
     expect(snapshot.results).toHaveLength(1);

--- a/src/__tests__/cli-paths.test.ts
+++ b/src/__tests__/cli-paths.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveHubConfigDir, resolveHubDbPath } from "../cli/paths.js";
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  delete process.env.DEVAGENT_HUB_CONFIG_DIR;
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("hub paths", () => {
+  it("uses DEVAGENT_HUB_CONFIG_DIR when provided", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "devagent-hub-config-"));
+    process.env.DEVAGENT_HUB_CONFIG_DIR = tempDir;
+
+    expect(resolveHubConfigDir()).toBe(tempDir);
+    expect(resolveHubDbPath()).toBe(join(tempDir, "state.db"));
+  });
+});

--- a/src/__tests__/local-runner-client.test.ts
+++ b/src/__tests__/local-runner-client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, test } from "vitest";
 import { LocalRunnerClient } from "../runner-client/local-runner-client.js";
 import { defaultConfig } from "../workflow/config.js";
 import { PROTOCOL_VERSION, type TaskExecutionRequest } from "@devagent-sdk/types";
+import { buildNodeScriptCommand } from "../runtime/node-runtime.js";
 
 const tempPaths: string[] = [];
 
@@ -145,4 +146,13 @@ test("LocalRunnerClient falls back to runner.bin when profile bin is absent", as
 
   assert.equal(result.status, "success");
   assert.match(await readFile(result.artifacts[0]!.path, "utf-8"), /runner bin output/);
+});
+
+test("LocalRunnerClient launches the default DevAgent CLI through Node", async () => {
+  const config = defaultConfig();
+  const client = new LocalRunnerClient(config, "/tmp/devagent cli.js");
+
+  const devagentAdapter = (client as any).runner.adapters[0];
+
+  assert.equal(devagentAdapter.command, buildNodeScriptCommand("/tmp/devagent cli.js"));
 });

--- a/src/__tests__/workflow-config.test.ts
+++ b/src/__tests__/workflow-config.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import {
   parseWorkflowConfig,
   loadWorkflowConfig,
+  resolveWorkflowConfig,
   defaultConfig,
   validateConfig,
   WorkflowConfigError,
@@ -96,14 +97,36 @@ describe("loadWorkflowConfig", () => {
     }
   });
 
-  it("returns defaults when file does not exist", () => {
+  it("infers npm-based verify commands when WORKFLOW.md is missing", () => {
     const dir = makeTmpDir();
-    const cfg = loadWorkflowConfig(dir);
-    expect(cfg).toEqual(defaultConfig());
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        scripts: {
+          test: "vitest run",
+          typecheck: "tsc --noEmit",
+        },
+      }),
+    );
+
+    const resolved = resolveWorkflowConfig(dir);
+
+    expect(resolved.source).toBe("inferred-node");
+    expect(resolved.detectedProjectKind).toBe("node");
+    expect(resolved.config.verify.commands).toEqual(["npm run test", "npm run typecheck"]);
   });
 
   it("uses fallback provider and model from env when WORKFLOW.md is missing", () => {
     const dir = makeTmpDir();
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        packageManager: "bun@1.3.10",
+        scripts: {
+          test: "bun test",
+        },
+      }),
+    );
     process.env.DEVAGENT_HUB_FALLBACK_PROVIDER = "chatgpt";
     process.env.DEVAGENT_HUB_FALLBACK_MODEL = "gpt-5.4";
 
@@ -111,6 +134,7 @@ describe("loadWorkflowConfig", () => {
 
     expect(cfg.runner.provider).toBe("chatgpt");
     expect(cfg.runner.model).toBe("gpt-5.4");
+    expect(cfg.verify.commands).toEqual(["bun run test"]);
   });
 
   it("reads and parses WORKFLOW.md from repo root", () => {
@@ -179,6 +203,26 @@ runner:
 `,
     );
     expect(() => loadWorkflowConfig(dir)).toThrow(WorkflowConfigError);
+  });
+
+  it("infers python verify commands when WORKFLOW.md is missing", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "pyproject.toml"), "[tool.pytest.ini_options]\naddopts = \"-q\"\n");
+    writeFileSync(join(dir, "test_sample.py"), "def test_example():\n    assert True\n");
+
+    const resolved = resolveWorkflowConfig(dir);
+
+    expect(resolved.source).toBe("inferred-python");
+    expect(resolved.config.verify.commands).toEqual(["python -m pytest"]);
+  });
+
+  it("fails fast when WORKFLOW.md is missing and no safe defaults can be inferred", () => {
+    const dir = makeTmpDir();
+
+    const resolved = resolveWorkflowConfig(dir);
+
+    expect(resolved.source).toBe("unknown");
+    expect(() => loadWorkflowConfig(dir)).toThrow(/could not infer safe defaults/i);
   });
 });
 

--- a/src/__tests__/workflow-service.test.ts
+++ b/src/__tests__/workflow-service.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -12,6 +12,7 @@ import type { GitHubCheck, GitHubComment, GitHubIssue, GitHubPR } from "../githu
 import type { RunnerClient } from "../runner-client/types.js";
 import type { Project } from "../canonical/types.js";
 import { PROTOCOL_VERSION, type ArtifactRef, type TaskExecutionEvent, type TaskExecutionRequest, type TaskExecutionResult } from "@devagent-sdk/types";
+import type { ResolvedWorkflowConfig } from "../workflow/config.js";
 
 const paths: string[] = [];
 process.env.DEVAGENT_HUB_SKIP_BASELINE_CHECKS = "1";
@@ -164,9 +165,10 @@ class StubRunnerClient implements RunnerClient {
   private readonly failureByTaskType: Partial<Record<TaskExecutionRequest["taskType"], { code: string; message: string }>>;
 
   constructor(
-    private readonly repoRoot: string,
+    protected readonly repoRoot: string,
     private readonly reviewSequence: string[],
     private readonly changedFilesByTaskType: Partial<Record<TaskExecutionRequest["taskType"], string[]>> = {},
+    private readonly changedFilesSequenceByTaskType: Partial<Record<TaskExecutionRequest["taskType"], string[][]>> = {},
     private readonly patchBytesByTaskType: Partial<Record<TaskExecutionRequest["taskType"], number>> = {},
     failureByTaskType: Partial<Record<TaskExecutionRequest["taskType"], { code: string; message: string }>> = {},
   ) {
@@ -216,6 +218,16 @@ class StubRunnerClient implements RunnerClient {
       taskId: request.taskId,
       status: failure ? "failed" : "success",
       artifacts: [artifact],
+      session: request.taskType === "verify"
+        ? undefined
+        : {
+            kind: "devagent-headless-v1",
+            payload: {
+              requestTaskId: request.taskId,
+              continuationMode: request.continuation?.mode ?? "fresh",
+            },
+          },
+      outcome: failure ? "no_progress" : "completed",
       metrics: {
         startedAt: "2026-03-10T00:00:00.000Z",
         finishedAt: "2026-03-10T00:00:01.000Z",
@@ -249,7 +261,7 @@ class StubRunnerClient implements RunnerClient {
     return request;
   }
 
-  private async ensureWorkspace(runId: string): Promise<string> {
+  protected async ensureWorkspace(runId: string): Promise<string> {
     const existing = this.workspaces.get(runId);
     if (existing) {
       return existing;
@@ -259,9 +271,17 @@ class StubRunnerClient implements RunnerClient {
     return workspacePath;
   }
 
-  private async writeArtifact(workspacePath: string, request: TaskExecutionRequest): Promise<ArtifactRef> {
+  protected async writeArtifact(workspacePath: string, request: TaskExecutionRequest): Promise<ArtifactRef> {
     await mkdir(workspacePath, { recursive: true });
-    const changedFiles = this.changedFilesByTaskType[request.taskType];
+    const queuedChangedFiles = this.changedFilesSequenceByTaskType[request.taskType];
+    const changedFiles = queuedChangedFiles?.length
+      ? queuedChangedFiles.shift()
+      : this.changedFilesByTaskType[request.taskType]
+        ?? (request.taskType === "implement"
+          ? ["src/implemented.ts"]
+          : request.taskType === "repair"
+            ? ["src/repaired.ts"]
+            : undefined);
     if (changedFiles) {
       await writeFile(
         join(workspacePath, ".devagent-changed-files.json"),
@@ -300,6 +320,66 @@ class StubRunnerClient implements RunnerClient {
       createdAt: "2026-03-10T00:00:01.000Z",
       mimeType: "text/markdown",
     };
+  }
+}
+
+class SharedWorkspaceContaminationRunnerClient extends StubRunnerClient {
+  private sharedWorkspacePath: string | null = null;
+
+  protected override async ensureWorkspace(_runId: string): Promise<string> {
+    if (this.sharedWorkspacePath) {
+      return this.sharedWorkspacePath;
+    }
+    this.sharedWorkspacePath = await createTempDir("devagent-hub-shared-run-");
+    await mkdir(this.sharedWorkspacePath, { recursive: true });
+    return this.sharedWorkspacePath;
+  }
+
+  protected override async writeArtifact(workspacePath: string, request: TaskExecutionRequest): Promise<ArtifactRef> {
+    const primaryRepository = request.execution.repositories.find((repository) =>
+      repository.repositoryId === request.execution.primaryRepositoryId
+    );
+    if ((request.taskType === "triage" || request.taskType === "plan") && primaryRepository?.readOnly === false) {
+      await writeFile(
+        join(workspacePath, ".devagent-changed-files.json"),
+        JSON.stringify(["README.md"], null, 2),
+      );
+    }
+    return super.writeArtifact(workspacePath, request);
+  }
+}
+
+class NestedPrimaryRepoRunnerClient extends StubRunnerClient {
+  protected override async ensureWorkspace(runId: string): Promise<string> {
+    const existing = await super.ensureWorkspace(runId);
+    const primaryRepoPath = join(existing, "repos", "primary");
+    await mkdir(join(existing, "repos"), { recursive: true });
+    if (!await this.pathExists(join(primaryRepoPath, ".git"))) {
+      git(existing, ["clone", this.repoRoot, primaryRepoPath]);
+    }
+    return existing;
+  }
+
+  protected override async writeArtifact(workspacePath: string, request: TaskExecutionRequest): Promise<ArtifactRef> {
+    const artifact = await super.writeArtifact(workspacePath, request);
+    if (request.taskType === "implement") {
+      const primaryRepoPath = join(workspacePath, "repos", "primary");
+      await writeFile(join(primaryRepoPath, "README.md"), "# repo\nnested change\n");
+    }
+    return artifact;
+  }
+
+  async cleanupRun(runId: string): Promise<void> {
+    await super.cleanupRun(runId);
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 
@@ -404,9 +484,11 @@ async function createService(
   reviewSequence: string[] = ["No defects found."],
   options: {
     changedFilesByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], string[]>>;
+    changedFilesSequenceByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], string[][]>>;
     patchBytesByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], number>>;
     failureByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], { code: string; message: string }>>;
     githubPushFailures?: number;
+    configResolution?: ResolvedWorkflowConfig;
   } = {},
 ) {
   const root = await createTempDir("devagent-hub-service-");
@@ -440,6 +522,7 @@ async function createService(
     repoRoot,
     [...reviewSequence],
     options.changedFilesByTaskType,
+    options.changedFilesSequenceByTaskType,
     options.patchBytesByTaskType,
     options.failureByTaskType,
   );
@@ -465,7 +548,14 @@ async function createService(
     github,
     repoRoot,
     runner,
-    service: new WorkflowService(store, github, runner, project, config),
+    service: new WorkflowService(
+      store,
+      github,
+      runner,
+      project,
+      config,
+      options.configResolution,
+    ),
   };
 }
 
@@ -477,8 +567,10 @@ function reopenService(input: {
   repoRoot: string;
   reviewSequence?: string[];
   changedFilesByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], string[]>>;
+  changedFilesSequenceByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], string[][]>>;
   patchBytesByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], number>>;
   failureByTaskType?: Partial<Record<TaskExecutionRequest["taskType"], { code: string; message: string }>>;
+  configResolution?: ResolvedWorkflowConfig;
 }) {
   const store = new CanonicalStore(input.dbPath);
   const github = new StubGitHubGateway(input.issue);
@@ -486,6 +578,7 @@ function reopenService(input: {
     input.repoRoot,
     [...(input.reviewSequence ?? ["No defects found."])],
     input.changedFilesByTaskType,
+    input.changedFilesSequenceByTaskType,
     input.patchBytesByTaskType,
     input.failureByTaskType,
   );
@@ -493,7 +586,7 @@ function reopenService(input: {
     store,
     github,
     runner,
-    service: new WorkflowService(store, github, runner, input.project, input.config),
+    service: new WorkflowService(store, github, runner, input.project, input.config, input.configResolution),
   };
 }
 
@@ -579,6 +672,171 @@ describe("WorkflowService", () => {
     expect(snapshot.tasks.map((task) => task.type)).toEqual(["triage", "plan"]);
     expect(snapshot.approvals).toHaveLength(1);
     expect(snapshot.events.length).toBeGreaterThan(0);
+
+    store.close();
+  });
+
+  it("sends triage and plan as readonly stages with explicit no-edit instructions", async () => {
+    const { store, service, runner } = await createService();
+
+    await service.start("42");
+
+    const triageRequest = runner.startedRequests.find((request) => request.taskType === "triage");
+    const planRequest = runner.startedRequests.find((request) => request.taskType === "plan");
+
+    expect(triageRequest?.execution.repositories.every((repository) => repository.readOnly)).toBe(true);
+    expect(planRequest?.execution.repositories.every((repository) => repository.readOnly)).toBe(true);
+    expect(triageRequest?.context.extraInstructions).toContain("Do not modify files.");
+    expect(triageRequest?.context.extraInstructions).toContain("Do not run verification commands.");
+    expect(planRequest?.context.extraInstructions).toContain("Only inspect current state and produce the requested artifact.");
+
+    store.close();
+  });
+
+  it("keeps implement writable for target repositories", async () => {
+    const { store, service, runner } = await createService(["No defects found."]);
+
+    const started = await service.start("42");
+    await service.resume(started.id);
+
+    const implementRequest = runner.startedRequests.find((request) => request.taskType === "implement");
+    const primaryExecutionRepository = implementRequest?.execution.repositories.find((repository) =>
+      repository.repositoryId === implementRequest.execution.primaryRepositoryId
+    );
+
+    expect(primaryExecutionRepository?.readOnly).toBe(false);
+
+    store.close();
+  });
+
+  it("prevents triage and plan from contaminating implement no-progress detection", async () => {
+    const repoRoot = await createTempDir("devagent-hub-contamination-repo-");
+    await initializeRepo(repoRoot);
+    const dbPath = join(await createTempDir("devagent-hub-db-"), "hub.db");
+    const issue: GitHubIssue = {
+      number: 42,
+      title: "Contamination regression",
+      body: "Prevent pre-implement mutation.",
+      labels: ["devagent"],
+      url: "https://github.com/org/repo/issues/42",
+      state: "open",
+      author: "eg",
+      createdAt: "2026-03-10T00:00:00.000Z",
+      comments: [],
+    };
+    const store = new CanonicalStore(dbPath);
+    const github = new StubGitHubGateway(issue);
+    const project: Project = {
+      id: "org/repo",
+      name: "repo",
+      repoRoot,
+      repoFullName: "org/repo",
+      workflowConfigPath: join(repoRoot, "WORKFLOW.md"),
+      allowedExecutors: ["devagent"],
+    };
+    store.upsertProject(project);
+    store.upsertWorkspace({
+      id: project.id,
+      name: project.name,
+      provider: "github",
+      primaryRepositoryId: `${project.id}:primary`,
+      workflowConfigPath: project.workflowConfigPath,
+      allowedExecutors: project.allowedExecutors,
+    });
+    store.upsertRepository({
+      id: `${project.id}:primary`,
+      workspaceId: project.id,
+      alias: "primary",
+      name: project.name,
+      repoRoot: project.repoRoot,
+      repoFullName: project.repoFullName,
+      defaultBranch: "main",
+      provider: "github",
+    });
+    const config = defaultConfig();
+    config.runner.bin = "devagent";
+    config.runner.provider = "chatgpt";
+    config.runner.model = "gpt-5.4";
+    const runner = new SharedWorkspaceContaminationRunnerClient(repoRoot, ["No defects found."], {}, {
+      implement: [
+        [],
+        [],
+      ],
+    });
+    const service = new WorkflowService(store, github, runner, project, config);
+
+    const started = await service.start("42");
+    const failed = await service.resume(started.id);
+    const triageRequest = runner.startedRequests.find((request) => request.taskType === "triage");
+    const planRequest = runner.startedRequests.find((request) => request.taskType === "plan");
+
+    expect(triageRequest?.execution.repositories.every((repository) => repository.readOnly)).toBe(true);
+    expect(planRequest?.execution.repositories.every((repository) => repository.readOnly)).toBe(true);
+    expect(failed.status).toBe("failed");
+    expect(failed.stage).toBe("implement");
+    expect(failed.statusReason).toContain("no repository changes after retry");
+
+    store.close();
+  });
+
+  it("detects implement changes from a nested primary repo workspace", async () => {
+    const root = await createTempDir("devagent-hub-nested-primary-");
+    const dbPath = join(root, "state.db");
+    const repoRoot = join(root, "repo");
+    await mkdir(repoRoot, { recursive: true });
+    await initializeRepo(repoRoot);
+    const store = new CanonicalStore(dbPath);
+    const issue: GitHubIssue = {
+      number: 42,
+      title: "Nested workspace regression",
+      body: "Detect git-worktree changes under repos/primary.",
+      labels: ["devagent"],
+      url: "https://github.com/org/repo/issues/42",
+      state: "open",
+      author: "eg",
+      createdAt: "2026-03-10T00:00:00.000Z",
+      comments: [],
+    };
+    const github = new StubGitHubGateway(issue);
+    const project: Project = {
+      id: "org/repo",
+      name: "repo",
+      repoRoot,
+      repoFullName: "org/repo",
+      workflowConfigPath: join(repoRoot, "WORKFLOW.md"),
+      allowedExecutors: ["devagent"],
+    };
+    store.upsertProject(project);
+    store.upsertWorkspace({
+      id: project.id,
+      name: project.name,
+      provider: "github",
+      primaryRepositoryId: `${project.id}:primary`,
+      workflowConfigPath: project.workflowConfigPath,
+      allowedExecutors: project.allowedExecutors,
+    });
+    store.upsertRepository({
+      id: `${project.id}:primary`,
+      workspaceId: project.id,
+      alias: "primary",
+      name: project.name,
+      repoRoot: project.repoRoot,
+      repoFullName: project.repoFullName,
+      defaultBranch: "main",
+      provider: "github",
+    });
+    const config = defaultConfig();
+    config.runner.bin = "devagent";
+    config.runner.provider = "chatgpt";
+    config.runner.model = "gpt-5.4";
+    const runner = new NestedPrimaryRepoRunnerClient(repoRoot, ["No defects found."]);
+    const service = new WorkflowService(store, github, runner, project, config);
+
+    const started = await service.start("42");
+    const resumed = await service.resume(started.id);
+
+    expect(resumed.status).toBe("waiting_approval");
+    expect(resumed.stage).toBe("review");
 
     store.close();
   });
@@ -707,6 +965,35 @@ describe("WorkflowService", () => {
     store.close();
   });
 
+  it("injects inferred workflow warnings into triage, plan, and implement requests", async () => {
+    const inferredConfig = defaultConfig();
+    const { store, service, runner } = await createService(["No defects found."], {
+      configResolution: {
+        config: inferredConfig,
+        source: "inferred-python",
+        warnings: [
+          "WORKFLOW.md is missing; inferred python workflow defaults.",
+          "Using inferred verify commands: python -m pytest",
+        ],
+        inferredVerifyCommands: ["python -m pytest"],
+        detectedProjectKind: "python",
+      },
+    });
+
+    const started = await service.start("42");
+    await service.resume(started.id);
+
+    const triageRequest = runner.startedRequests.find((request) => request.taskType === "triage");
+    const planRequest = runner.startedRequests.find((request) => request.taskType === "plan");
+    const implementRequest = runner.startedRequests.find((request) => request.taskType === "implement");
+
+    expect(triageRequest?.context.extraInstructions?.join("\n")).toContain("inferred python workflow defaults");
+    expect(planRequest?.context.extraInstructions?.join("\n")).toContain("python -m pytest");
+    expect(implementRequest?.context.extraInstructions?.join("\n")).toContain("Detected project kind: python");
+
+    store.close();
+  });
+
   it("pauses for manual approval when implement changes exceed the review file threshold", async () => {
     const { store, service } = await createService(["No defects found."], {
       changedFilesByTaskType: {
@@ -739,6 +1026,52 @@ describe("WorkflowService", () => {
     expect(failed.status).toBe("failed");
     expect(failed.stage).toBe("implement");
     expect(failed.statusReason).toContain("review.run_max_changed_files");
+
+    store.close();
+  });
+
+  it("retries implement once when the first attempt produces no repository changes", async () => {
+    const { store, service, runner } = await createService(["No defects found."], {
+      changedFilesSequenceByTaskType: {
+        implement: [
+          [],
+          ["src/fixed.ts"],
+        ],
+      },
+    });
+    const started = await service.start("42");
+    const resumed = await service.resume(started.id);
+    const snapshot = service.getSnapshot(started.id);
+    const implementTask = snapshot.tasks.find((task) => task.type === "implement");
+
+    expect(resumed.status).toBe("waiting_approval");
+    expect(resumed.stage).toBe("review");
+    expect(implementTask?.attemptIds).toHaveLength(2);
+    expect(runner.startedRequests.filter((request) => request.taskType === "implement")).toHaveLength(2);
+    expect(runner.startedRequests.filter((request) => request.taskType === "implement")[1]?.continuation?.mode).toBe("resume");
+    expect(service.getLatestContinuationSession(started.id, ["implement"])?.kind).toBe("devagent-headless-v1");
+
+    store.close();
+  });
+
+  it("fails implement when retry still produces no repository changes", async () => {
+    const { store, service, runner } = await createService(["No defects found."], {
+      changedFilesSequenceByTaskType: {
+        implement: [
+          [],
+          [],
+        ],
+      },
+    });
+    const started = await service.start("42");
+    const failed = await service.resume(started.id);
+    const implementRequests = runner.startedRequests.filter((request) => request.taskType === "implement");
+
+    expect(failed.status).toBe("failed");
+    expect(failed.stage).toBe("implement");
+    expect(failed.statusReason).toContain("no repository changes after retry");
+    expect(implementRequests).toHaveLength(2);
+    expect(implementRequests[1]?.continuation?.reason).toBe("retry_no_progress");
 
     store.close();
   });

--- a/src/canonical/types.ts
+++ b/src/canonical/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ContinuationSession,
   TaskExecutionEvent,
   TaskExecutionResult,
   WorkflowTaskType,
@@ -142,6 +143,7 @@ export type ExecutionAttempt = {
   resultPath?: string;
   workspacePath?: string;
   eventLogPath?: string;
+  session?: ContinuationSession;
 };
 
 export type Approval = {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,21 +1,19 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { CanonicalStore } from "../persistence/canonical-store.js";
 import { GhCliGateway } from "../github/gh-cli-gateway.js";
-import { loadWorkflowConfig } from "../workflow/config.js";
+import { resolveWorkflowConfig } from "../workflow/config.js";
 import { LocalRunnerClient } from "../runner-client/local-runner-client.js";
 import { WorkflowService } from "../workflows/service.js";
 import { resolveReviewableImportRepoRoot } from "./reviewable-import.js";
-
-const CONFIG_DIR = join(homedir(), ".config", "devagent-hub");
-const DB_PATH = join(CONFIG_DIR, "state.db");
+import { resolveHubConfigDir, resolveHubDbPath } from "./paths.js";
+import { resolveNodeRuntime } from "../runtime/node-runtime.js";
 
 function ensureConfigDir(): void {
-  mkdirSync(CONFIG_DIR, { recursive: true });
+  mkdirSync(resolveHubConfigDir(), { recursive: true });
 }
 
 function detectRepoRoot(cwd = process.cwd()): string {
@@ -73,8 +71,11 @@ function createService(repoRootOverride?: string): { store: CanonicalStore; serv
   ensureConfigDir();
   const repoRoot = repoRootOverride ?? detectRepoRoot();
   const repoFullName = detectRepoFullName(repoRoot);
-  const config = loadWorkflowConfig(repoRoot);
-  const store = new CanonicalStore(DB_PATH);
+  const resolvedConfig = resolveWorkflowConfig(repoRoot);
+  if (resolvedConfig.source === "unknown") {
+    throw new Error(resolvedConfig.warnings.join(" "));
+  }
+  const store = new CanonicalStore(resolveHubDbPath());
   const project = store.upsertProject({
     id: repoFullName,
     name: repoFullName.split("/")[1] ?? repoFullName,
@@ -89,9 +90,10 @@ function createService(repoRootOverride?: string): { store: CanonicalStore; serv
     service: new WorkflowService(
       store,
       new GhCliGateway(),
-      new LocalRunnerClient(config),
+      new LocalRunnerClient(resolvedConfig.config),
       project,
-      config,
+      resolvedConfig.config,
+      resolvedConfig,
     ),
   };
 }
@@ -176,7 +178,7 @@ function createServiceForReviewableImport(
 
 function createStore(): CanonicalStore {
   ensureConfigDir();
-  return new CanonicalStore(DB_PATH);
+  return new CanonicalStore(resolveHubDbPath());
 }
 
 function hasFlag(args: string[], flag: string): boolean {
@@ -204,20 +206,7 @@ function spawnDetachedContinue(workflowId: string, cwd = process.cwd()): void {
 }
 
 function resolveDetachedRuntime(): string {
-  if (!process.versions.bun) {
-    return process.execPath;
-  }
-  const candidates = [
-    process.env.DEVAGENT_HUB_NODE_PATH,
-    "/opt/homebrew/bin/node",
-    "/usr/local/bin/node",
-  ].filter((candidate): candidate is string => Boolean(candidate));
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return process.execPath;
+  return resolveNodeRuntime();
 }
 
 function formatStatus(view: ReturnType<WorkflowService["getStatusView"]>): string {

--- a/src/cli/paths.ts
+++ b/src/cli/paths.ts
@@ -1,0 +1,14 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export function resolveHubConfigDir(): string {
+  const configured = process.env.DEVAGENT_HUB_CONFIG_DIR?.trim();
+  if (configured) {
+    return resolve(configured);
+  }
+  return join(homedir(), ".config", "devagent-hub");
+}
+
+export function resolveHubDbPath(): string {
+  return join(resolveHubConfigDir(), "state.db");
+}

--- a/src/persistence/canonical-store.ts
+++ b/src/persistence/canonical-store.ts
@@ -122,7 +122,8 @@ CREATE TABLE IF NOT EXISTS execution_attempts (
   status TEXT NOT NULL,
   result_path TEXT,
   workspace_path TEXT,
-  event_log_path TEXT
+  event_log_path TEXT,
+  session_json TEXT
 );
 
 CREATE TABLE IF NOT EXISTS approvals (
@@ -298,6 +299,7 @@ type ExecutionAttemptRow = {
   result_path: string | null;
   workspace_path: string | null;
   event_log_path: string | null;
+  session_json: string | null;
 };
 
 type ApprovalRow = {
@@ -453,6 +455,7 @@ function mapExecutionAttemptRow(row: ExecutionAttemptRow): ExecutionAttempt {
     resultPath: row.result_path ?? undefined,
     workspacePath: row.workspace_path ?? undefined,
     eventLogPath: row.event_log_path ?? undefined,
+    session: row.session_json ? JSON.parse(row.session_json) : undefined,
   };
 }
 
@@ -594,6 +597,15 @@ export class CanonicalStore {
         this.db.exec("ALTER TABLE execution_attempts ADD COLUMN event_log_path TEXT");
       } catch (error) {
         if (!(error instanceof Error) || !error.message.includes("duplicate column name: event_log_path")) {
+          throw error;
+        }
+      }
+    }
+    if (!names.has("session_json")) {
+      try {
+        this.db.exec("ALTER TABLE execution_attempts ADD COLUMN session_json TEXT");
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.includes("duplicate column name: session_json")) {
           throw error;
         }
       }
@@ -1038,6 +1050,7 @@ export class CanonicalStore {
     runnerId: string;
     workspacePath?: string;
     eventLogPath?: string;
+    session?: ExecutionAttempt["session"];
   }): ExecutionAttempt {
     const attempt: ExecutionAttempt = {
       id: randomUUID(),
@@ -1048,29 +1061,41 @@ export class CanonicalStore {
       status: "running",
       workspacePath: input.workspacePath,
       eventLogPath: input.eventLogPath,
+      session: input.session,
     };
     this.db.prepare(`
-      INSERT INTO execution_attempts (id, task_id, executor_id, runner_id, started_at, status, workspace_path, event_log_path)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(attempt.id, attempt.taskId, attempt.executorId, attempt.runnerId, attempt.startedAt, attempt.status, attempt.workspacePath ?? null, attempt.eventLogPath ?? null);
+      INSERT INTO execution_attempts (id, task_id, executor_id, runner_id, started_at, status, workspace_path, event_log_path, session_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      attempt.id,
+      attempt.taskId,
+      attempt.executorId,
+      attempt.runnerId,
+      attempt.startedAt,
+      attempt.status,
+      attempt.workspacePath ?? null,
+      attempt.eventLogPath ?? null,
+      attempt.session ? JSON.stringify(attempt.session) : null,
+    );
     return attempt;
   }
 
-  updateAttemptMetadata(id: string, patch: { workspacePath?: string; eventLogPath?: string }): ExecutionAttempt {
+  updateAttemptMetadata(id: string, patch: { workspacePath?: string; eventLogPath?: string; session?: ExecutionAttempt["session"] }): ExecutionAttempt {
     const current = this.getAttempt(id);
     if (!current) throw new Error(`Attempt ${id} not found`);
     const next: ExecutionAttempt = {
       ...current,
       workspacePath: patch.workspacePath ?? current.workspacePath,
       eventLogPath: patch.eventLogPath ?? current.eventLogPath,
+      session: patch.session ?? current.session,
     };
     this.db.prepare(`
-      UPDATE execution_attempts SET workspace_path = ?, event_log_path = ? WHERE id = ?
-    `).run(next.workspacePath ?? null, next.eventLogPath ?? null, id);
+      UPDATE execution_attempts SET workspace_path = ?, event_log_path = ?, session_json = ? WHERE id = ?
+    `).run(next.workspacePath ?? null, next.eventLogPath ?? null, next.session ? JSON.stringify(next.session) : null, id);
     return next;
   }
 
-  finishAttempt(id: string, result: { status: ExecutionAttempt["status"]; resultPath?: string; workspacePath?: string; eventLogPath?: string }): ExecutionAttempt {
+  finishAttempt(id: string, result: { status: ExecutionAttempt["status"]; resultPath?: string; workspacePath?: string; eventLogPath?: string; session?: ExecutionAttempt["session"] }): ExecutionAttempt {
     const current = this.getAttempt(id);
     if (!current) throw new Error(`Attempt ${id} not found`);
     const next: ExecutionAttempt = {
@@ -1079,11 +1104,20 @@ export class CanonicalStore {
       resultPath: result.resultPath,
       workspacePath: result.workspacePath ?? current.workspacePath,
       eventLogPath: result.eventLogPath ?? current.eventLogPath,
+      session: result.session ?? current.session,
       finishedAt: now(),
     };
     this.db.prepare(`
-      UPDATE execution_attempts SET status = ?, result_path = ?, workspace_path = ?, event_log_path = ?, finished_at = ? WHERE id = ?
-    `).run(next.status, next.resultPath ?? null, next.workspacePath ?? null, next.eventLogPath ?? null, next.finishedAt, id);
+      UPDATE execution_attempts SET status = ?, result_path = ?, workspace_path = ?, event_log_path = ?, session_json = ?, finished_at = ? WHERE id = ?
+    `).run(
+      next.status,
+      next.resultPath ?? null,
+      next.workspacePath ?? null,
+      next.eventLogPath ?? null,
+      next.session ? JSON.stringify(next.session) : null,
+      next.finishedAt,
+      id,
+    );
     return next;
   }
 

--- a/src/runner-client/local-runner-client.ts
+++ b/src/runner-client/local-runner-client.ts
@@ -10,6 +10,7 @@ import type { TaskExecutionEvent, TaskExecutionRequest, TaskExecutionResult } fr
 import { resolveBaselineRepoPath, resolveWorkspaceRoot } from "../baseline/manifest.js";
 import type { RunnerClient } from "./types.js";
 import type { WorkflowConfig } from "../workflow/config.js";
+import { buildNodeScriptCommand } from "../runtime/node-runtime.js";
 
 export class LocalRunnerClient implements RunnerClient {
   private readonly runner: LocalRunner;
@@ -28,7 +29,7 @@ export class LocalRunnerClient implements RunnerClient {
     );
     this.runner = new LocalRunner({
       adapters: [
-        new DevAgentAdapter(`bun ${resolvedDevagentCliPath}`),
+        new DevAgentAdapter(buildNodeScriptCommand(resolvedDevagentCliPath)),
         new CodexAdapter((request) => this.resolveCommand(request)),
         new ClaudeAdapter((request) => this.resolveCommand(request)),
         new OpenCodeAdapter((request) => this.resolveCommand(request)),

--- a/src/runtime/node-runtime.ts
+++ b/src/runtime/node-runtime.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+
+const NODE_CANDIDATES = [
+  "/opt/homebrew/bin/node",
+  "/usr/local/bin/node",
+  "/usr/bin/node",
+] as const;
+
+export function resolveNodeRuntime(): string {
+  if (!process.versions.bun) {
+    return process.execPath;
+  }
+
+  const configured = process.env.DEVAGENT_HUB_NODE_PATH?.trim();
+  if (configured && existsSync(configured)) {
+    return configured;
+  }
+
+  for (const candidate of NODE_CANDIDATES) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return process.execPath;
+}
+
+export function buildNodeScriptCommand(scriptPath: string): string {
+  return `${quoteCommandArg(resolveNodeRuntime())} ${quoteCommandArg(scriptPath)}`;
+}
+
+function quoteCommandArg(value: string): string {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
+    return value;
+  }
+  return JSON.stringify(value);
+}

--- a/src/workflow/config.ts
+++ b/src/workflow/config.ts
@@ -1,5 +1,5 @@
 import { parse } from "yaml";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 // ─── Valid values (must match DevAgent's workflow-contract.ts) ────
@@ -112,6 +112,23 @@ export interface WorkflowConfig {
     max_unresolved_escalations: number;
   };
 }
+
+export type WorkflowConfigSource =
+  | "workflow-file"
+  | "inferred-node"
+  | "inferred-bun"
+  | "inferred-python"
+  | "unknown";
+
+export type DetectedProjectKind = "node" | "bun" | "python" | "unknown";
+
+export type ResolvedWorkflowConfig = {
+  config: WorkflowConfig;
+  source: WorkflowConfigSource;
+  warnings: string[];
+  inferredVerifyCommands: string[];
+  detectedProjectKind: DetectedProjectKind;
+};
 
 export function defaultConfig(): WorkflowConfig {
   return {
@@ -322,6 +339,143 @@ function fallbackConfigFromEnv(): Partial<WorkflowConfig> {
   };
 }
 
+function configWithFallbackEnv(): WorkflowConfig {
+  return deepMerge(
+    defaultConfig() as unknown as Record<string, unknown>,
+    fallbackConfigFromEnv() as Record<string, unknown>,
+  ) as unknown as WorkflowConfig;
+}
+
+function getPackageManagerPrefix(packageManager: string | undefined): string {
+  if (packageManager?.startsWith("yarn")) return "corepack yarn";
+  if (packageManager?.startsWith("pnpm")) return "pnpm";
+  if (packageManager?.startsWith("bun")) return "bun run";
+  return "npm run";
+}
+
+function inferJavascriptVerifyCommands(repoRoot: string): { commands: string[]; kind: DetectedProjectKind } | null {
+  const pkgPath = join(repoRoot, "package.json");
+  if (!existsSync(pkgPath)) {
+    return null;
+  }
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      scripts?: Record<string, string>;
+      packageManager?: string;
+    };
+    const scripts = pkg.scripts ?? {};
+    const prefix = getPackageManagerPrefix(pkg.packageManager);
+    const commands: string[] = [];
+    for (const scriptName of ["test:implementation", "test:unit", "test", "typecheck", "lint", "build"]) {
+      if (scripts[scriptName]) {
+        commands.push(`${prefix} ${scriptName}`);
+      }
+    }
+    if (commands.length === 0) {
+      return null;
+    }
+    const kind: DetectedProjectKind =
+      pkg.packageManager?.startsWith("bun") || existsSync(join(repoRoot, "bun.lock")) || existsSync(join(repoRoot, "bun.lockb"))
+        ? "bun"
+        : "node";
+    return {
+      commands,
+      kind,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const PYTHON_TEST_FILENAME = /^test_.*\.py$|.*_test\.py$/;
+const IGNORED_DIRS = new Set([".git", "node_modules", ".venv", "venv", "__pycache__"]);
+
+function fileContains(path: string, snippet: string): boolean {
+  if (!existsSync(path)) return false;
+  try {
+    return readFileSync(path, "utf-8").includes(snippet);
+  } catch {
+    return false;
+  }
+}
+
+function hasPytestConfig(repoRoot: string): boolean {
+  const pytestIni = join(repoRoot, "pytest.ini");
+  if (existsSync(pytestIni)) return true;
+
+  const pyproject = join(repoRoot, "pyproject.toml");
+  if (fileContains(pyproject, "[tool.pytest")) return true;
+
+  const toxIni = join(repoRoot, "tox.ini");
+  if (fileContains(toxIni, "[pytest]")) return true;
+
+  const setupCfg = join(repoRoot, "setup.cfg");
+  if (fileContains(setupCfg, "[tool:pytest]")) return true;
+
+  for (const req of ["requirements.txt", "requirements-dev.txt"]) {
+    if (fileContains(join(repoRoot, req), "pytest")) return true;
+  }
+
+  return false;
+}
+
+function directoryContainsPythonFile(dir: string, depth: number, anyPythonFile: boolean): boolean {
+  if (depth < 0) return false;
+
+  let entries: Array<{
+    name: string;
+    isDirectory(): boolean;
+    isFile(): boolean;
+  }>;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true, encoding: "utf8" }) as Array<{
+      name: string;
+      isDirectory(): boolean;
+      isFile(): boolean;
+    }>;
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      if (directoryContainsPythonFile(join(dir, entry.name), depth - 1, anyPythonFile)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (!entry.isFile() || !entry.name.endsWith(".py")) continue;
+    if (anyPythonFile) return true;
+    if (PYTHON_TEST_FILENAME.test(entry.name)) return true;
+  }
+
+  return false;
+}
+
+function hasPythonTests(repoRoot: string): boolean {
+  const testsDir = join(repoRoot, "tests");
+  if (existsSync(testsDir) && directoryContainsPythonFile(testsDir, 5, true)) {
+    return true;
+  }
+
+  return directoryContainsPythonFile(repoRoot, 4, false);
+}
+
+function inferPythonVerifyCommands(repoRoot: string): string[] | null {
+  if (!hasPythonTests(repoRoot)) {
+    return null;
+  }
+  if (hasPytestConfig(repoRoot)) {
+    return ["python -m pytest"];
+  }
+  return existsSync(join(repoRoot, "tests"))
+    ? ["python -m unittest discover -s tests"]
+    : ["python -m unittest discover"];
+}
+
 /**
  * Parse YAML frontmatter from a WORKFLOW.md content string and return a
  * fully-populated WorkflowConfig (parsed values overlaid on defaults).
@@ -338,23 +492,86 @@ export function parseWorkflowConfig(content: string): WorkflowConfig {
   return deepMerge(defaultConfig() as unknown as Record<string, unknown>, parsed) as unknown as WorkflowConfig;
 }
 
+export function resolveWorkflowConfig(repoRoot: string): ResolvedWorkflowConfig {
+  const filePath = join(repoRoot, "WORKFLOW.md");
+  if (existsSync(filePath)) {
+    const content = readFileSync(filePath, "utf-8");
+    const config = parseWorkflowConfig(content);
+    validateConfig(config);
+    return {
+      config,
+      source: "workflow-file",
+      warnings: [],
+      inferredVerifyCommands: [],
+      detectedProjectKind: "unknown",
+    };
+  }
+
+  const baseConfig = configWithFallbackEnv();
+  const jsInference = inferJavascriptVerifyCommands(repoRoot);
+  if (jsInference) {
+    const config = {
+      ...baseConfig,
+      verify: {
+        commands: jsInference.commands,
+      },
+    };
+    validateConfig(config);
+    const source: WorkflowConfigSource = jsInference.kind === "bun" ? "inferred-bun" : "inferred-node";
+    return {
+      config,
+      source,
+      warnings: [
+        `WORKFLOW.md is missing; inferred ${jsInference.kind} workflow defaults.`,
+        `Using inferred verify commands: ${jsInference.commands.join(", ")}`,
+      ],
+      inferredVerifyCommands: jsInference.commands,
+      detectedProjectKind: jsInference.kind,
+    };
+  }
+
+  const pythonCommands = inferPythonVerifyCommands(repoRoot);
+  if (pythonCommands) {
+    const config = {
+      ...baseConfig,
+      verify: {
+        commands: pythonCommands,
+      },
+    };
+    validateConfig(config);
+    return {
+      config,
+      source: "inferred-python",
+      warnings: [
+        "WORKFLOW.md is missing; inferred python workflow defaults.",
+        `Using inferred verify commands: ${pythonCommands.join(", ")}`,
+      ],
+      inferredVerifyCommands: pythonCommands,
+      detectedProjectKind: "python",
+    };
+  }
+
+  return {
+    config: baseConfig,
+    source: "unknown",
+    warnings: [
+      "WORKFLOW.md is missing and Hub could not infer safe defaults for this repository.",
+      "Add WORKFLOW.md with explicit verify.commands before starting a workflow.",
+    ],
+    inferredVerifyCommands: [],
+    detectedProjectKind: "unknown",
+  };
+}
+
 /**
  * Read WORKFLOW.md from the given repo root, parse it, and validate.
  * Returns defaults if the file does not exist.
  * Throws WorkflowConfigError on invalid values.
  */
 export function loadWorkflowConfig(repoRoot: string): WorkflowConfig {
-  const filePath = join(repoRoot, "WORKFLOW.md");
-  let config: WorkflowConfig;
-  if (!existsSync(filePath)) {
-    config = deepMerge(
-      defaultConfig() as unknown as Record<string, unknown>,
-      fallbackConfigFromEnv() as Record<string, unknown>,
-    ) as unknown as WorkflowConfig;
-  } else {
-    const content = readFileSync(filePath, "utf-8");
-    config = parseWorkflowConfig(content);
+  const resolved = resolveWorkflowConfig(repoRoot);
+  if (resolved.source === "unknown") {
+    throw new WorkflowConfigError(resolved.warnings.join(" "));
   }
-  validateConfig(config);
-  return config;
+  return resolved.config;
 }

--- a/src/workflows/service.ts
+++ b/src/workflows/service.ts
@@ -11,7 +11,7 @@ import {
   readBranchHead,
   readCurrentBaselineSystemSnapshot,
 } from "../baseline/manifest.js";
-import type { WorkflowConfig } from "../workflow/config.js";
+import type { ResolvedWorkflowConfig, WorkflowConfig } from "../workflow/config.js";
 import { resolveSkills } from "../workflow/skill-resolver.js";
 import { CanonicalStore } from "../persistence/canonical-store.js";
 import type {
@@ -25,6 +25,7 @@ import type {
 import type {
   ArtifactKind,
   CapabilitySet,
+  ContinuationSession,
   ExecutorSpec,
   TaskExecutionRequest,
   TaskExecutionResult,
@@ -97,6 +98,10 @@ function artifactKindForStage(stage: WorkflowTaskType): ArtifactKind {
   }
 }
 
+function isReadonlyStage(stage: WorkflowTaskType): boolean {
+  return stage === "triage" || stage === "plan" || stage === "review";
+}
+
 function isFailureStatus(status: WorkflowInstance["status"]): boolean {
   return status === "failed" || status === "cancelled";
 }
@@ -116,6 +121,13 @@ export class WorkflowService {
     private readonly runnerClient: RunnerClient,
     private readonly project: Project,
     private readonly config: WorkflowConfig,
+    private readonly configResolution: ResolvedWorkflowConfig = {
+      config,
+      source: "workflow-file",
+      warnings: [],
+      inferredVerifyCommands: [],
+      detectedProjectKind: "unknown",
+    },
   ) {}
 
   async syncIssues(): Promise<WorkItem[]> {
@@ -703,6 +715,26 @@ export class WorkflowService {
     });
   }
 
+  getLatestContinuationSession(
+    workflowId: string,
+    stages?: WorkflowTaskType[],
+  ): ContinuationSession | undefined {
+    const stageSet = stages ? new Set(stages) : null;
+    const tasks = [...this.store.listTasks(workflowId)].reverse();
+    for (const task of tasks) {
+      if (stageSet && !stageSet.has(task.type)) {
+        continue;
+      }
+      const attempts = [...this.store.listAttempts(task.id)].reverse();
+      for (const attempt of attempts) {
+        if (attempt.session) {
+          return attempt.session;
+        }
+      }
+    }
+    return undefined;
+  }
+
   private assertWorkflowContinuationSafe(
     workflow: WorkflowInstance,
     requireWorkBranch: boolean,
@@ -754,6 +786,25 @@ export class WorkflowService {
       reasoning: (profile.reasoning ?? this.config.runner.reasoning) as ExecutorSpec["reasoning"],
       approvalMode: (profile.approval_mode ?? this.config.runner.approval_mode) as ExecutorSpec["approvalMode"],
     };
+  }
+
+  private inferredConfigInstructions(stage: WorkflowTaskType): string[] {
+    if (!["triage", "plan", "implement"].includes(stage)) {
+      return [];
+    }
+    if (this.configResolution.source === "workflow-file") {
+      return [];
+    }
+    const verifyCommands = this.configResolution.inferredVerifyCommands.length > 0
+      ? this.configResolution.inferredVerifyCommands.join(", ")
+      : "none";
+    return [
+      `Hub inferred workflow defaults because WORKFLOW.md is missing.`,
+      `Detected project kind: ${this.configResolution.detectedProjectKind}.`,
+      `Inferred verify commands: ${verifyCommands}.`,
+      ...this.configResolution.warnings,
+      "Do not assume Bun-based commands unless the inferred project kind is bun.",
+    ];
   }
 
   private findActiveWorkflowForWorkItem(workItemId: string): WorkflowInstance | undefined {
@@ -896,7 +947,17 @@ export class WorkflowService {
     stage: WorkflowTaskType,
     overrides: StageContextOverrides = {},
   ): Promise<WorkflowInstance> {
-    const extraInstructions = [...(overrides.extraInstructions ?? [])];
+    const extraInstructions = [
+      ...(overrides.extraInstructions ?? []),
+      ...this.inferredConfigInstructions(stage),
+    ];
+    if (stage === "triage" || stage === "plan") {
+      extraInstructions.push(
+        "Do not modify files.",
+        "Do not run verification commands.",
+        "Only inspect current state and produce the requested artifact.",
+      );
+    }
     if (stage === "implement") {
       extraInstructions.push(...(await this.latestArtifactInstructions(workflow.id, "plan", "Accepted plan")));
     }
@@ -938,7 +999,7 @@ export class WorkflowService {
         baseRef: pinnedRepositoryBaseRefs.get(repository.alias),
         workBranch: workflow.branch,
         isolation: "git-worktree",
-        readOnly: stage === "review" || !isTargetRepository,
+        readOnly: isReadonlyStage(stage) || !isTargetRepository,
       } as const;
     });
     const capabilities: CapabilitySet = {
@@ -951,9 +1012,8 @@ export class WorkflowService {
     };
     const reviewable = workflow.reviewableId ? this.store.getReviewable(workflow.reviewableId) : undefined;
 
-    const request: TaskExecutionRequest = {
+    const baseRequest = {
       protocolVersion: PROTOCOL_VERSION,
-      taskId: task.id,
       taskType: stage,
       workspaceRef: {
         id: this.project.id,
@@ -1001,55 +1061,116 @@ export class WorkflowService {
         comments: overrides.comments,
         changedFilesHint: overrides.changedFilesHint,
         skills: resolveSkills(this.config, stage, overrides.changedFilesHint),
-        extraInstructions: extraInstructions.length > 0 ? extraInstructions : undefined,
       },
       expectedArtifacts: [artifactKindForStage(stage)],
-    };
+    } satisfies Omit<TaskExecutionRequest, "taskId">;
 
-    const { runId } = await this.runnerClient.startTask(request);
-    const attempt = this.store.createAttempt({
-      taskId: task.id,
-      executorId: request.executor.executorId,
-      runnerId: runId,
-    });
-    this.store.updateTask(task.id, {
-      runnerId: runId,
-      attemptIds: [...task.attemptIds, attempt.id],
-    });
-    const initialMetadata = await this.runnerClient.inspect(runId);
-    this.store.updateAttemptMetadata(attempt.id, {
-      workspacePath: initialMetadata.workspacePath,
-      eventLogPath: initialMetadata.eventLogPath,
-    });
+    const maxAttempts = stage === "implement" || stage === "repair" ? 2 : 1;
+    let retryInstruction: string | undefined;
+    let continuation: TaskExecutionRequest["continuation"] | undefined;
+    let attemptIds = [...task.attemptIds];
 
-    await this.runnerClient.subscribe(runId, (event) => this.store.recordEvent(task.id, event));
-    const result = await this.runnerClient.awaitResult(runId);
-    const metadata = await this.runnerClient.inspect(runId);
+    for (let attemptIndex = 1; attemptIndex <= maxAttempts; attemptIndex += 1) {
+      const request: TaskExecutionRequest = {
+        ...baseRequest,
+        taskId: attemptIndex === 1 ? task.id : `${task.id}:retry-${attemptIndex - 1}`,
+        continuation,
+        context: {
+          ...baseRequest.context,
+          extraInstructions: [
+            ...extraInstructions,
+            ...(retryInstruction ? [retryInstruction] : []),
+          ].filter(Boolean),
+        },
+      };
 
-    this.store.finishAttempt(attempt.id, {
-      status: result.status === "success" ? "success" : result.status === "cancelled" ? "cancelled" : "failed",
-      resultPath: metadata.resultPath,
-      workspacePath: metadata.workspacePath,
-      eventLogPath: metadata.eventLogPath,
-    });
-    this.store.recordArtifacts(task.id, result.artifacts);
-    this.store.recordResult(task.id, result);
-    this.store.updateTask(task.id, {
-      status: result.status === "success" ? "completed" : result.status === "cancelled" ? "cancelled" : "failed",
-    });
-
-    if (result.status !== "success") {
-      await this.runnerClient.cleanupRun(runId);
-      return this.store.updateWorkflowInstance(workflow.id, {
-        stage,
-        status: result.status === "cancelled" ? "cancelled" : "failed",
-        statusReason: result.error?.message,
+      const { runId } = await this.runnerClient.startTask(request);
+      const attempt = this.store.createAttempt({
+        taskId: task.id,
+        executorId: request.executor.executorId,
+        runnerId: runId,
       });
-    }
+      attemptIds = [...attemptIds, attempt.id];
+      this.store.updateTask(task.id, {
+        runnerId: runId,
+        attemptIds,
+      });
+      const initialMetadata = await this.runnerClient.inspect(runId);
+      this.store.updateAttemptMetadata(attempt.id, {
+        workspacePath: initialMetadata.workspacePath,
+        eventLogPath: initialMetadata.eventLogPath,
+      });
 
-    const gatedWorkflow = this.enforceReviewPolicy(workflow, stage, metadata.workspacePath);
-    if (gatedWorkflow) {
-      return gatedWorkflow;
+      await this.runnerClient.subscribe(runId, (event) => this.store.recordEvent(task.id, event));
+      const result = await this.runnerClient.awaitResult(runId);
+      const metadata = await this.runnerClient.inspect(runId);
+
+      this.store.finishAttempt(attempt.id, {
+        status: result.status === "success" ? "success" : result.status === "cancelled" ? "cancelled" : "failed",
+        resultPath: metadata.resultPath,
+        workspacePath: metadata.workspacePath,
+        eventLogPath: metadata.eventLogPath,
+        session: result.session,
+      });
+      this.store.recordArtifacts(task.id, result.artifacts);
+      this.store.recordResult(task.id, result);
+      this.store.updateTask(task.id, {
+        status: result.status === "success" ? "completed" : result.status === "cancelled" ? "cancelled" : "failed",
+      });
+
+      if (result.status !== "success") {
+        await this.runnerClient.cleanupRun(runId);
+        return this.store.updateWorkflowInstance(workflow.id, {
+          stage,
+          status: result.status === "cancelled" ? "cancelled" : "failed",
+          statusReason: result.error?.message,
+        });
+      }
+
+      if (stage === "implement" || stage === "repair") {
+        const changedFiles = this.readChangedFiles(workflow, metadata.workspacePath);
+        if (changedFiles.length === 0) {
+          const outcomeReason = result.outcomeReason ?? "no_repo_changes";
+          const noProgressResult: PersistedExecutionResult = {
+            ...result,
+            outcome: "no_progress",
+            outcomeReason,
+          };
+          this.store.recordResult(task.id, noProgressResult);
+          await this.runnerClient.cleanupRun(runId);
+
+          const causeSuffix = outcomeReason === "no_repo_changes" ? "" : ` (executor reported ${outcomeReason})`;
+          if (attemptIndex < maxAttempts) {
+            retryInstruction =
+              `The previous ${stage} attempt produced no repository changes${causeSuffix}. Continue and make the requested code changes before finishing.`;
+            continuation = executor.executorId === "devagent" && result.session
+              ? {
+                  mode: "resume",
+                  reason: "retry_no_progress",
+                  instructions: retryInstruction,
+                  session: result.session,
+                }
+              : undefined;
+            this.store.updateTask(task.id, {
+              status: "running",
+            });
+            continue;
+          }
+
+          return this.store.updateWorkflowInstance(workflow.id, {
+            stage,
+            status: "failed",
+            statusReason: `${stage} produced no repository changes after retry${causeSuffix}.`,
+          });
+        }
+      }
+
+      const gatedWorkflow = this.enforceReviewPolicy(workflow, stage, metadata.workspacePath);
+      if (gatedWorkflow) {
+        return gatedWorkflow;
+      }
+
+      return this.store.getWorkflowInstance(workflow.id) ?? workflow;
     }
 
     return this.store.getWorkflowInstance(workflow.id) ?? workflow;
@@ -1116,15 +1237,22 @@ export class WorkflowService {
   }
 
   private readChangedFiles(workflow: WorkflowInstance, workspacePath: string): string[] {
-    const markerPath = join(workspacePath, ".devagent-changed-files.json");
-    if (existsSync(markerPath)) {
+    const primaryRepoPath = this.resolveWorkspacePrimaryRepoPath(workflow, workspacePath);
+    const markerPaths = [
+      join(workspacePath, ".devagent-changed-files.json"),
+      join(primaryRepoPath, ".devagent-changed-files.json"),
+    ];
+    for (const markerPath of markerPaths) {
+      if (!existsSync(markerPath)) {
+        continue;
+      }
       const raw = readFileSync(markerPath, "utf-8");
       return [...new Set((JSON.parse(raw) as string[]).filter(Boolean))];
     }
 
     const candidates: Array<{ cwd: string; args: string[] }> = [
       {
-        cwd: workspacePath,
+        cwd: primaryRepoPath,
         args: ["diff", "--name-only", workflow.baseSha],
       },
       {
@@ -1168,15 +1296,22 @@ export class WorkflowService {
   }
 
   private readPatchBytes(workflow: WorkflowInstance, workspacePath: string): number {
-    const markerPath = join(workspacePath, ".devagent-patch-bytes.txt");
-    if (existsSync(markerPath)) {
+    const primaryRepoPath = this.resolveWorkspacePrimaryRepoPath(workflow, workspacePath);
+    const markerPaths = [
+      join(workspacePath, ".devagent-patch-bytes.txt"),
+      join(primaryRepoPath, ".devagent-patch-bytes.txt"),
+    ];
+    for (const markerPath of markerPaths) {
+      if (!existsSync(markerPath)) {
+        continue;
+      }
       const raw = Number.parseInt(readFileSync(markerPath, "utf-8").trim(), 10);
       return Number.isFinite(raw) ? raw : 0;
     }
 
     const candidates: Array<{ cwd: string; args: string[] }> = [
       {
-        cwd: workspacePath,
+        cwd: primaryRepoPath,
         args: ["diff", "--binary", workflow.baseSha],
       },
       {


### PR DESCRIPTION
## Summary
- harden the Hub runtime and workflow config resolution for real repository runs
- make triage and plan read-only, add no-progress retry handling, and fix nested git-worktree diff detection
- repin the Hub baseline to merged devagent-sdk, devagent-runner, and devagent SHAs

## Testing
- bunx tsc --noEmit
- bun run test
- bun run build
- bun run check:oss
- live workflow validation on a fresh repo without WORKFLOW.md